### PR TITLE
Improve team member photo upload flow

### DIFF
--- a/client/src/pages/team-members-page.tsx
+++ b/client/src/pages/team-members-page.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState, type ChangeEvent } from "react";
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { Header } from "@/components/layout/header";
 import { Sidebar } from "@/components/layout/sidebar";
@@ -25,6 +25,8 @@ export default function TeamMembersPage() {
     imageType: "url",
     imagePath: null,
   });
+  const imageUploadInputRef = useRef<HTMLInputElement | null>(null);
+  const [isUploadingImage, setIsUploadingImage] = useState(false);
   
   const { data: teamMembers, isLoading } = useQuery<TeamMember[]>({
     queryKey: ['/api/team-members'],
@@ -133,9 +135,10 @@ export default function TeamMembersPage() {
       imageType: "url",
       imagePath: null,
     });
+    setIsUploadingImage(false);
     setIsModalOpen(true);
   };
-  
+
   const handleEditClick = (member: TeamMember) => {
     setEditMember(member);
     setFormData({
@@ -146,6 +149,7 @@ export default function TeamMembersPage() {
       imageType: member.imageType,
       imagePath: member.imagePath,
     });
+    setIsUploadingImage(false);
     setIsModalOpen(true);
   };
   
@@ -171,14 +175,100 @@ export default function TeamMembersPage() {
   
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     const { name, value } = e.target;
-    setFormData((prev) => ({ ...prev, [name]: value }));
+    setFormData((prev) => ({
+      ...prev,
+      [name]: value,
+      ...(name === "imageUrl"
+        ? {
+            imageType: "url",
+            imagePath: null,
+          }
+        : {}),
+    }));
   };
-  
+
+  const handleImageFileChange = async (event: ChangeEvent<HTMLInputElement>) => {
+    if (!event.target.files || event.target.files.length === 0) {
+      return;
+    }
+
+    const file = event.target.files[0];
+    const formDataUpload = new FormData();
+    formDataUpload.append("image", file);
+
+    if (editMember) {
+      formDataUpload.append("teamMemberId", String(editMember.id));
+    }
+
+    setIsUploadingImage(true);
+
+    try {
+      const response = await fetch("/api/team-members/upload-image", {
+        method: "POST",
+        body: formDataUpload,
+        credentials: "include",
+      });
+
+      const data = await response.json().catch(() => null);
+
+      if (!response.ok) {
+        const message = data?.message || "Failed to upload image";
+        throw new Error(message);
+      }
+
+      const newImageUrl = typeof data?.imageUrl === "string" ? data.imageUrl : "";
+
+      if (!newImageUrl) {
+        throw new Error("Upload completed but no image URL was returned");
+      }
+
+      setFormData((prev) => ({
+        ...prev,
+        imageUrl: newImageUrl,
+        imageType: "url",
+        imagePath: null,
+      }));
+
+      if (data?.teamMember) {
+        const updatedMember = data.teamMember as TeamMember;
+        setEditMember(updatedMember);
+        setFormData((prev) => ({
+          ...prev,
+          imageUrl: updatedMember.imageUrl,
+          imageType: updatedMember.imageType,
+          imagePath: updatedMember.imagePath,
+        }));
+      } else if (editMember) {
+        setEditMember((prev) => (prev ? { ...prev, imageUrl: newImageUrl, imageType: "url", imagePath: null } : prev));
+      }
+
+      if (editMember) {
+        queryClient.invalidateQueries({ queryKey: ['/api/team-members'] });
+      }
+
+      toast({
+        title: "Profile photo uploaded",
+        description: editMember
+          ? "The new photo has been published to the live site."
+          : "The uploaded photo URL has been added to this team member.",
+      });
+    } catch (error) {
+      toast({
+        title: "Failed to upload image",
+        description: error instanceof Error ? error.message : "An unexpected error occurred while uploading the image.",
+        variant: "destructive",
+      });
+    } finally {
+      setIsUploadingImage(false);
+      event.target.value = "";
+    }
+  };
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     createMemberMutation.mutate(formData as InsertTeamMember);
   };
-  
+
   const handleCloseModal = () => {
     setIsModalOpen(false);
     setEditMember(null);
@@ -190,6 +280,10 @@ export default function TeamMembersPage() {
       imageType: "url",
       imagePath: null,
     });
+    setIsUploadingImage(false);
+    if (imageUploadInputRef.current) {
+      imageUploadInputRef.current.value = "";
+    }
   };
   
   return (
@@ -384,16 +478,64 @@ export default function TeamMembersPage() {
                     </div>
                     
                     <div>
-                      <Label htmlFor="imageUrl">Profile Image URL</Label>
-                      <Input
-                        id="imageUrl"
-                        name="imageUrl"
-                        value={formData.imageUrl}
-                        onChange={handleInputChange}
-                        placeholder="https://example.com/profile-image.jpg"
+                      <Label htmlFor="imageUrl">Profile Image</Label>
+                      <div className="flex gap-2">
+                        <Input
+                          id="imageUrl"
+                          name="imageUrl"
+                          value={formData.imageUrl}
+                          onChange={handleInputChange}
+                          placeholder="https://example.com/profile-image.jpg"
+                          className="flex-1"
+                        />
+                        <Button
+                          type="button"
+                          variant="outline"
+                          onClick={() => imageUploadInputRef.current?.click()}
+                          disabled={isUploadingImage}
+                          className="shrink-0 flex items-center gap-1"
+                        >
+                          {isUploadingImage ? (
+                            <>
+                              <Loader2 className="h-4 w-4 animate-spin" />
+                              <span>Uploading...</span>
+                            </>
+                          ) : (
+                            <>
+                              <Upload className="h-4 w-4" />
+                              <span>Upload photo</span>
+                            </>
+                          )}
+                        </Button>
+                      </div>
+                      <input
+                        ref={imageUploadInputRef}
+                        type="file"
+                        accept="image/*"
+                        className="hidden"
+                        onChange={handleImageFileChange}
                       />
+                      {formData.imageUrl && (
+                        <div className="mt-2 flex items-center gap-3">
+                          <div className="h-16 w-16 overflow-hidden rounded-full border border-gray-200 bg-gray-100">
+                            <img
+                              src={formData.imageUrl}
+                              alt={`${formData.name || "Team member"} profile preview`}
+                              className="h-full w-full object-cover"
+                              onError={(event) => {
+                                event.currentTarget.src = "https://placehold.co/200x200?text=Image";
+                              }}
+                            />
+                          </div>
+                          <span className="text-xs text-gray-500 break-all">
+                            {formData.imageUrl}
+                          </span>
+                        </div>
+                      )}
                       <p className="text-xs text-gray-500 mt-1">
-                        Provide a direct link to the profile image. Recommended size: 300x300 pixels.
+                        {editMember
+                          ? "Upload a new photo or paste an image URL to instantly refresh the live team page."
+                          : "Upload a photo or paste an image URL. Save the team member to publish the new image."}
                       </p>
                     </div>
                   </div>

--- a/client/src/pages/team-members-page.tsx
+++ b/client/src/pages/team-members-page.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState, type ChangeEvent } from "react";
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { Header } from "@/components/layout/header";
 import { Sidebar } from "@/components/layout/sidebar";
@@ -25,6 +25,8 @@ export default function TeamMembersPage() {
     imageType: "url",
     imagePath: null,
   });
+  const imageUploadInputRef = useRef<HTMLInputElement | null>(null);
+  const [isUploadingImage, setIsUploadingImage] = useState(false);
   
   const { data: teamMembers, isLoading } = useQuery<TeamMember[]>({
     queryKey: ['/api/team-members'],
@@ -133,9 +135,10 @@ export default function TeamMembersPage() {
       imageType: "url",
       imagePath: null,
     });
+    setIsUploadingImage(false);
     setIsModalOpen(true);
   };
-  
+
   const handleEditClick = (member: TeamMember) => {
     setEditMember(member);
     setFormData({
@@ -146,6 +149,7 @@ export default function TeamMembersPage() {
       imageType: member.imageType,
       imagePath: member.imagePath,
     });
+    setIsUploadingImage(false);
     setIsModalOpen(true);
   };
   
@@ -171,14 +175,100 @@ export default function TeamMembersPage() {
   
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     const { name, value } = e.target;
-    setFormData((prev) => ({ ...prev, [name]: value }));
+    setFormData((prev) => ({
+      ...prev,
+      [name]: value,
+      ...(name === "imageUrl"
+        ? {
+            imageType: "url",
+            imagePath: null,
+          }
+        : {}),
+    }));
   };
-  
+
+  const handleImageFileChange = async (event: ChangeEvent<HTMLInputElement>) => {
+    if (!event.target.files || event.target.files.length === 0) {
+      return;
+    }
+
+    const inputElement = event.target;
+    const { files } = inputElement;
+
+    if (!files || files.length === 0) {
+      return;
+    }
+
+    const file = files[0];
+    const formDataUpload = new FormData();
+    formDataUpload.append("image", file);
+
+    if (editMember) {
+      formDataUpload.append("teamMemberId", String(editMember.id));
+    }
+
+    setIsUploadingImage(true);
+
+    try {
+      const response = await apiRequest("POST", "/api/team-members/upload-image", formDataUpload);
+      const data = (await response.json().catch(() => null)) as {
+        imageUrl?: string;
+        teamMember?: TeamMember;
+      } | null;
+
+      const newImageUrl = typeof data?.imageUrl === "string" ? data.imageUrl : "";
+
+      if (!newImageUrl) {
+        throw new Error("Upload completed but no image URL was returned");
+      }
+
+      setFormData((prev) => ({
+        ...prev,
+        imageUrl: newImageUrl,
+        imageType: "url",
+        imagePath: null,
+      }));
+
+      if (data?.teamMember) {
+        const updatedMember = data.teamMember as TeamMember;
+        setEditMember(updatedMember);
+        setFormData((prev) => ({
+          ...prev,
+          imageUrl: updatedMember.imageUrl,
+          imageType: updatedMember.imageType,
+          imagePath: updatedMember.imagePath,
+        }));
+      } else if (editMember) {
+        setEditMember((prev) => (prev ? { ...prev, imageUrl: newImageUrl, imageType: "url", imagePath: null } : prev));
+      }
+
+      if (editMember) {
+        queryClient.invalidateQueries({ queryKey: ['/api/team-members'] });
+      }
+
+      toast({
+        title: "Profile photo uploaded",
+        description: editMember
+          ? "The new photo has been published to the live site."
+          : "The uploaded photo URL has been added to this team member.",
+      });
+    } catch (error) {
+      toast({
+        title: "Failed to upload image",
+        description: error instanceof Error ? error.message : "An unexpected error occurred while uploading the image.",
+        variant: "destructive",
+      });
+    } finally {
+      setIsUploadingImage(false);
+      inputElement.value = "";
+    }
+  };
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     createMemberMutation.mutate(formData as InsertTeamMember);
   };
-  
+
   const handleCloseModal = () => {
     setIsModalOpen(false);
     setEditMember(null);
@@ -190,6 +280,10 @@ export default function TeamMembersPage() {
       imageType: "url",
       imagePath: null,
     });
+    setIsUploadingImage(false);
+    if (imageUploadInputRef.current) {
+      imageUploadInputRef.current.value = "";
+    }
   };
   
   return (
@@ -384,16 +478,64 @@ export default function TeamMembersPage() {
                     </div>
                     
                     <div>
-                      <Label htmlFor="imageUrl">Profile Image URL</Label>
-                      <Input
-                        id="imageUrl"
-                        name="imageUrl"
-                        value={formData.imageUrl}
-                        onChange={handleInputChange}
-                        placeholder="https://example.com/profile-image.jpg"
+                      <Label htmlFor="imageUrl">Profile Image</Label>
+                      <div className="flex gap-2">
+                        <Input
+                          id="imageUrl"
+                          name="imageUrl"
+                          value={formData.imageUrl}
+                          onChange={handleInputChange}
+                          placeholder="https://example.com/profile-image.jpg"
+                          className="flex-1"
+                        />
+                        <Button
+                          type="button"
+                          variant="outline"
+                          onClick={() => imageUploadInputRef.current?.click()}
+                          disabled={isUploadingImage}
+                          className="shrink-0 flex items-center gap-1"
+                        >
+                          {isUploadingImage ? (
+                            <>
+                              <Loader2 className="h-4 w-4 animate-spin" />
+                              <span>Uploading...</span>
+                            </>
+                          ) : (
+                            <>
+                              <Upload className="h-4 w-4" />
+                              <span>Upload photo</span>
+                            </>
+                          )}
+                        </Button>
+                      </div>
+                      <input
+                        ref={imageUploadInputRef}
+                        type="file"
+                        accept="image/*"
+                        className="hidden"
+                        onChange={handleImageFileChange}
                       />
+                      {formData.imageUrl && (
+                        <div className="mt-2 flex items-center gap-3">
+                          <div className="h-16 w-16 overflow-hidden rounded-full border border-gray-200 bg-gray-100">
+                            <img
+                              src={formData.imageUrl}
+                              alt={`${formData.name || "Team member"} profile preview`}
+                              className="h-full w-full object-cover"
+                              onError={(event) => {
+                                event.currentTarget.src = "https://placehold.co/200x200?text=Image";
+                              }}
+                            />
+                          </div>
+                          <span className="text-xs text-gray-500 break-all">
+                            {formData.imageUrl}
+                          </span>
+                        </div>
+                      )}
                       <p className="text-xs text-gray-500 mt-1">
-                        Provide a direct link to the profile image. Recommended size: 300x300 pixels.
+                        {editMember
+                          ? "Upload a new photo or paste an image URL to instantly refresh the live team page."
+                          : "Upload a photo or paste an image URL. Save the team member to publish the new image."}
                       </p>
                     </div>
                   </div>

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,5 +1,6 @@
 import type { Express, Request, Response } from "express";
 import { createServer, type Server } from "http";
+import { unlink } from "fs/promises";
 import { storage } from "./storage";
 import { setupAuth } from "./auth";
 import { setupAirtableRoutes, deleteAirtableRecord } from "./integrations/airtable";
@@ -16,6 +17,8 @@ import { getMigrationProgress } from "./utils/migrationProgress";
 import { getAllApiStatuses } from "./api-status";
 import { log } from "./vite";
 import * as path from "path";
+import { upload as teamMemberImageUpload } from "./utils/fileUpload";
+import { uploadImageToImgBB } from "./utils/imgbbUploader";
 import { insertTeamMemberSchema, insertArticleSchema, insertCarouselQuoteSchema, insertImageAssetSchema, insertIntegrationSettingSchema, insertActivityLogSchema, insertAdminRequestSchema } from "@shared/schema";
 import { ZodError } from "zod";
 
@@ -178,6 +181,78 @@ export async function registerRoutes(app: Express): Promise<Server> {
       res.status(204).send();
     } catch (error) {
       res.status(500).json({ message: "Failed to delete team member" });
+    }
+  });
+
+  app.post("/api/team-members/upload-image", isAuthenticated, teamMemberImageUpload.single("image"), async (req, res) => {
+    if (!req.file) {
+      return res.status(400).json({ message: "No file uploaded" });
+    }
+
+    const filePath = req.file.path;
+
+    try {
+      const imgbbResult = await uploadImageToImgBB({
+        path: req.file.path,
+        filename: req.file.originalname,
+        size: req.file.size,
+        mimetype: req.file.mimetype,
+      });
+
+      if (!imgbbResult) {
+        return res.status(500).json({ message: "Failed to upload image to ImgBB. Please verify your ImgBB configuration." });
+      }
+
+      let updatedTeamMember = null;
+      const rawTeamMemberId = Array.isArray(req.body?.teamMemberId)
+        ? req.body.teamMemberId[0]
+        : req.body?.teamMemberId;
+
+      if (rawTeamMemberId !== undefined && rawTeamMemberId !== null && `${rawTeamMemberId}`.trim() !== "") {
+        const teamMemberId = Number(rawTeamMemberId);
+
+        if (Number.isNaN(teamMemberId)) {
+          return res.status(400).json({ message: "Invalid team member ID provided" });
+        }
+
+        const teamMember = await storage.updateTeamMember(teamMemberId, {
+          imageUrl: imgbbResult.url,
+          imageType: "url",
+          imagePath: null,
+        });
+
+        if (!teamMember) {
+          return res.status(404).json({ message: "Team member not found" });
+        }
+
+        updatedTeamMember = teamMember;
+
+        await storage.createActivityLog({
+          userId: req.user?.id,
+          action: "update",
+          resourceType: "team_member",
+          resourceId: teamMemberId.toString(),
+          details: {
+            imageUrl: imgbbResult.url,
+            updatedField: "imageUrl",
+          },
+        });
+      }
+
+      return res.json({
+        imageUrl: imgbbResult.url,
+        imgbb: imgbbResult,
+        teamMember: updatedTeamMember,
+      });
+    } catch (error) {
+      console.error("Error uploading team member image:", error);
+
+      if (!res.headersSent) {
+        const message = error instanceof Error ? error.message : "Failed to upload team member image";
+        res.status(500).json({ message });
+      }
+    } finally {
+      await unlink(filePath).catch(() => {});
     }
   });
 


### PR DESCRIPTION
## Summary
- extend the shared apiRequest helper to support FormData and other BodyInit payloads while still handling JSON defaults
- reuse the shared helper in the team member photo upload flow and guard file access to avoid stale input references

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68fe477e64208323936441faf176cdb6