### PR TITLE
Secure default admin credentials via Airtable

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,17 @@ Facebook requires HTTPS for OAuth login. To enable this in development:
 
 ## 🔐 Authentication
 
-The application uses session-based authentication. Default admin credentials will be created during first setup.
+The application uses session-based authentication. Default administrator credentials are pulled securely from Airtable during first setup instead of being hard-coded in the repository.
+
+1. Create an Airtable table (defaults to `AdminCredentials`) with a record that includes username and password fields (defaults to `Username` and `Password`).
+2. Configure environment variables so `scripts/createAdmin.js` can fetch the record:
+   - `AIRTABLE_API_KEY`
+   - `AIRTABLE_BASE_ID`
+   - `ADMIN_CREDENTIALS_RECORD_ID`
+   - Optional overrides: `ADMIN_CREDENTIALS_TABLE`, `ADMIN_CREDENTIALS_USERNAME_FIELD`, `ADMIN_CREDENTIALS_PASSWORD_FIELD`
+3. Run `node scripts/createAdmin.js` to create the admin account using the fetched credentials.
+
+Optionally set `VITE_DEFAULT_ADMIN_USERNAME` (to match the Airtable username) so the UI can remind you to rotate off the default account. After signing in, create a new administrator with a unique password, then disable or remove the default credentials in Airtable.
 
 ## 📚 API Documentation
 

--- a/client/src/pages/user-management-page.tsx
+++ b/client/src/pages/user-management-page.tsx
@@ -52,6 +52,7 @@ type EditUserFormValues = z.infer<typeof editUserSchema>;
 
 export default function UserManagementPage() {
   const { user: currentUser } = useAuth();
+  const defaultAdminUsername = import.meta.env.VITE_DEFAULT_ADMIN_USERNAME;
   const { toast } = useToast();
   const queryClient = useQueryClient();
   const [editModalOpen, setEditModalOpen] = useState(false);
@@ -427,11 +428,11 @@ export default function UserManagementPage() {
               </div>
             )}
             
-            {currentUser && currentUser.id === 2 && (
+            {currentUser && defaultAdminUsername && currentUser.username === defaultAdminUsername && (
               <Alert className="mt-4">
                 <AlertTriangle className="h-4 w-4" />
                 <AlertDescription>
-                  You are using the default admin account (admin). It is recommended to create a new admin account with a strong password.
+                  You are using the default admin account ({defaultAdminUsername}). It is recommended to create a new admin account with a strong password.
                 </AlertDescription>
               </Alert>
             )}

--- a/scripts/createAdmin.js
+++ b/scripts/createAdmin.js
@@ -5,30 +5,74 @@ import pg from 'pg';
 const { Client } = pg;
 const scryptAsync = promisify(scrypt);
 
+function getEnvVar(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
 async function hashPassword(password) {
   const salt = randomBytes(16).toString('hex');
   const buf = await scryptAsync(password, salt, 64);
   return `${buf.toString('hex')}.${salt}`;
 }
 
+async function fetchAdminCredentialsFromAirtable() {
+  const apiKey = getEnvVar('AIRTABLE_API_KEY');
+  const baseId = getEnvVar('AIRTABLE_BASE_ID');
+  const tableName = process.env.ADMIN_CREDENTIALS_TABLE || 'AdminCredentials';
+  const recordId = getEnvVar('ADMIN_CREDENTIALS_RECORD_ID');
+  const usernameField = process.env.ADMIN_CREDENTIALS_USERNAME_FIELD || 'Username';
+  const passwordField = process.env.ADMIN_CREDENTIALS_PASSWORD_FIELD || 'Password';
+
+  const url = `https://api.airtable.com/v0/${baseId}/${encodeURIComponent(tableName)}/${recordId}`;
+
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+    },
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Failed to fetch admin credentials from Airtable: ${response.status} ${errorText}`);
+  }
+
+  const data = await response.json();
+  const username = data?.fields?.[usernameField];
+  const password = data?.fields?.[passwordField];
+
+  if (!username || !password) {
+    throw new Error(
+      `Airtable record ${recordId} is missing required fields: ${usernameField} and/or ${passwordField}`
+    );
+  }
+
+  console.log(`Fetched admin username from Airtable: ${username}`);
+  return { username, password };
+}
+
 async function setupAdminUser() {
   const client = new Client({
     connectionString: process.env.DATABASE_URL,
   });
-  
+
   try {
+    const { username, password } = await fetchAdminCredentialsFromAirtable();
     await client.connect();
-    
-    // Clear previous admin
-    await client.query('DELETE FROM users WHERE username = $1', ['admin']);
-    
+
+    // Clear previous admin accounts
+    await client.query('DELETE FROM users WHERE username = ANY($1)', [['admin', 'websitedev', username]]);
+
     // Create new admin
-    const hashedPassword = await hashPassword('admin123');
+    const hashedPassword = await hashPassword(password);
     const result = await client.query(
       'INSERT INTO users (username, password, is_admin) VALUES ($1, $2, $3) RETURNING id',
-      ['admin', hashedPassword, true]
+      [username, hashedPassword, true]
     );
-    
+
     console.log('Admin user created with ID:', result.rows[0].id);
   } catch (err) {
     console.error('Error creating admin user:', err);


### PR DESCRIPTION
## Summary
- fetch the default admin credentials from an Airtable record configured via environment variables instead of hard-coding them
- allow the user management page to show a default-admin reminder based on a configurable username
- update authentication docs with Airtable setup steps and configuration options

## Testing
- `npm run check` *(fails: npm is not installed in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693315834084832397fc185bb1382988)